### PR TITLE
Only accepts number

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
           <div class="input-info">
             <div class="input-fields">
               <input id="name-input" type="text" name="" placeholder="Name of Hedgehog">
-              <input id="hoglet-input" type="text" name="" placeholder="Number of Hoglets">
+              <input id="hoglet-input" type="number" name="" placeholder="Number of Hoglets">
               <input id="allergies-input" type="text" name="" placeholder="Allergies">
               <button id="invite-btn" type="button" name="button" disabled>INVITE!</button>
             </div>

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,16 @@
+### Type of change made:
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+### Detailed Description
+
+### Why is this change required? What problem does it solve?
+
+### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
+
+### Files modified:
+- [ ] index.html
+- [ ] styles.css
+- [ ] main.js
+- [ ] Other files:

--- a/styles.css
+++ b/styles.css
@@ -103,6 +103,12 @@ input[type=text] {
   color: #3B3F70;
 }
 
+input[type=number] {
+  padding-left: 10px;
+  font-size: 16px;
+  color: #3B3F70;
+}
+
 input::placeholder {
   color: #3B3F70;
 }


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Detailed Description
-Added functionality so that only a number can be entered in the hoglet input field.

### Why is this change required? What problem does it solve?
- Not required just helpful

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?
-When I changed the type to number it effected my css styling for that one input box. Add another style for that specific box and it was fine.

### Files modified:
- [ ] index.html
- [X] styles.css
- [X] main.js
- [ ] Other files:
